### PR TITLE
Start busybox crond in the entrypoint.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run extra commands on the entrypoint
 ------------------------------------
 
 If you need to execute some command before httpd starts (i.e. a cron daemon inside
-the container), you can bind-mount a file /usr/local/bin/autorun.sh that will
+the container), you can bind-mount a file `/usr/local/bin/autorun.sh` that will
 be executed during the entrypoint. Add the following volume
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Add this line to your `/etc/crontab` to let Awstats analyze your logs every 10 m
 Advanced
 ========
 
+Run extra commands on the entrypoint
+------------------------------------
+
+If you need to execute some command before httpd starts (i.e. a cron daemon inside
+the container), you can bind-mount a file /usr/local/bin/autorun.sh that will
+be executed during the entrypoint. Add the following volume
+
+```
+...
+    --volume /path/to/my/autorun.sh:/usr/local/bin/autorun.sh:ro \
+...
+```
+
 Analyze old log files
 ---------------------
 
@@ -103,18 +116,5 @@ LOGFILES=(
 for lf in "${LOGFILES[@]}"; do
     docker exec awstats /usr/lib/awstats/cgi-bin/awstats.pl -update -config=my_website -LogFile="$lf"
 done
-```
-
-Run extra commands on the entrypoint
-------------------------------------
-
-If you need to execute some command before httpd starts (i.e. a cron daemon inside
-the container), you can bind-mount a file /usr/local/bin/autorun.sh that will
-be executed during the entrypoint. Add the following volume
-
-```
-...
-    --volume /path/to/my/autorun.sh:/usr/local/bin/autorun.sh:ro \
-...
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,3 +104,17 @@ for lf in "${LOGFILES[@]}"; do
     docker exec awstats /usr/lib/awstats/cgi-bin/awstats.pl -update -config=my_website -LogFile="$lf"
 done
 ```
+
+Run extra commands on the entrypoint
+------------------------------------
+
+If you need to execute some command before httpd starts (i.e. a cron daemon inside
+the container), you can bind-mount a file /usr/local/bin/autorun.sh that will
+be executed during the entrypoint. Add the following volume
+
+```
+...
+    --volume /path/to/my/autorun.sh:/usr/local/bin/autorun.sh:ro \
+...
+```
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-/usr/sbin/crond -L /var/lib/awstats/crond.log -l 8
+[[ -f /usr/local/bin/autorun.sh ]] && . /usr/local/bin/autorun.sh
+
 envsubst < /etc/awstats/awstats_env.conf > /etc/awstats/awstats.conf
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+/usr/sbin/crond -L /var/lib/awstats/crond.log -l 8
 envsubst < /etc/awstats/awstats_env.conf > /etc/awstats/awstats.conf
 
 exec "$@"


### PR DESCRIPTION
I found it the easiest way to update stats in kubernetes: the cron files should 
be bind-mounted on /etc/periodic/{15min,daily,hourly,monthly,weekly}/script.
The crond process running on the background should use <2MB resident 
memory (on x86_64)