### PR TITLE
Allow the execution of an autorun.sh in the entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM httpd:2.4.41-alpine
 ENV AWSTATS_VERSION 7.7-r0
 ENV MOD_PERL_VERSION 2.0.11
 
-RUN apk add --no-cache awstats=${AWSTATS_VERSION} gettext \
+RUN apk add --no-cache awstats=${AWSTATS_VERSION} gettext tzdata \
     && apk add --no-cache --virtual .build-dependencies gcc libc-dev make wget perl-dev \
     && cd /tmp \
     && wget https://www-eu.apache.org/dist/perl/mod_perl-$MOD_PERL_VERSION.tar.gz \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Add this line to your `/etc/crontab` to let Awstats analyze your logs every 10 m
 */10 * * * * root docker exec awstats awstats_updateall.pl now > /dev/null
 ```
 
+By default, the timezone in the container will be UTC. To configure a different 
+timezone in your container, set the environment variable `TZ` to your timezone, 
+adding the following to your command line at the container start:
+
+```
+    --env TZ="Antarctica/South_Pole"
+```
+
 
 Advanced
 ========

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Add this line to your `/etc/crontab` to let Awstats analyze your logs every 10 m
 Advanced
 ========
 
+Run extra commands on the entrypoint
+------------------------------------
+
+If you need to execute some command before httpd starts (i.e. a cron daemon inside
+the container), you can bind-mount a file `/usr/local/bin/autorun.sh` that will
+be executed during the entrypoint. Add the following volume
+
+```
+...
+    --volume /path/to/my/autorun.sh:/usr/local/bin/autorun.sh:ro \
+...
+```
+
 Analyze old log files
 ---------------------
 
@@ -104,3 +117,4 @@ for lf in "${LOGFILES[@]}"; do
     docker exec awstats /usr/lib/awstats/cgi-bin/awstats.pl -update -config=my_website -LogFile="$lf"
 done
 ```
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[[ -f /usr/local/bin/autorun.sh ]] && . /usr/local/bin/autorun.sh
+
 envsubst < /etc/awstats/awstats_env.conf > /etc/awstats/awstats.conf
 
 exec "$@"


### PR DESCRIPTION
If a file /usr/local/bin/autorun.sh is bind-mounted will be executed during the start
of the container. That gives more elasticity than only starting a cron daemon.